### PR TITLE
Iterators

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2021-12-05"

--- a/src/groupby.rs
+++ b/src/groupby.rs
@@ -1,0 +1,124 @@
+
+/// GroupBy Iterator Object
+pub struct GroupBy<I, P>
+where
+    I: Iterator,
+    P: FnMut(&I::Item, &I::Item) -> bool
+{
+    /// Input Iterator
+    range: I, 
+
+    /// Predicate function to groupby on
+    pred: P,  
+
+    /// Buffer to hold last item
+    /// I would just store an Option<I::Item> here
+    /// but the next function takes a mutable reference of the iterator
+    /// and that prevents me from taking the last item
+    /// from GroupBy and updating it without cloning. 
+    /// 
+    /// So we use a Vec and pop out the last item and 
+    /// push in the new last item.
+    buf: Vec<I::Item>, 
+}
+
+/// implement Iterator trait
+impl<I, P> Iterator for GroupBy<I, P> 
+where
+    I: Iterator,
+    P: FnMut(&I::Item, &I::Item) -> bool
+{
+    type Item = std::vec::IntoIter::<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut arr: Vec<I::Item> = Vec::new();
+        if self.buf.len() == 0 {
+            return None
+        }
+        arr.push(self.buf.pop().unwrap());
+        while let Some(b) = self.range.next() {
+            if (self.pred)(&arr[0], &b) {
+                arr.push(b);
+            } else {
+                self.buf.push(b);
+                break;
+            }
+        } 
+        Some(arr.into_iter())
+    }
+}
+
+/// Create new trait for any iterator that provides function group_by
+/// i.e range.group_by(|a, b| a == b)
+pub trait GroupByItr: Iterator {
+    fn group_by<'a, P>(self, pred: P) -> GroupBy<Self, P>
+    where
+        Self: Sized,
+        P: FnMut(&Self::Item, &Self::Item) -> bool
+    {
+        // preload the iterator
+        // without cloning
+        let mut itr = self.into_iter();
+        let front = itr.next();
+        let mut arr: Vec<Self::Item> = Vec::new();
+        if !front.is_none() {
+            arr.push(front.unwrap());
+        }
+        GroupBy {
+            range: itr,
+            pred: pred,
+            buf: arr,
+        }
+    }
+}
+
+/// Apparently this is need to implement the Trait
+impl<I: Iterator> GroupByItr for I {}
+
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_groupby() {
+        use crate::groupby::GroupByItr;
+        let range = vec![
+            String::from("test"),
+            String::from("test"),
+            String::from("test2"),
+            String::from("a"),
+            String::from("b"),
+            String::from("c"),
+            String::from("c"),
+            String::from("d"),
+            String::from("e"),
+        ];
+
+        let val = range.clone().into_iter().group_by(|a, b| a == b).map(|x| x.collect::<Vec<String>>()).collect::<Vec<Vec<String>>>();
+        let correct = vec![
+            vec![String::from("test"),
+            String::from("test")],
+            vec![String::from("test2")],
+            vec![String::from("a")],
+            vec![String::from("b")],
+            vec![String::from("c"),
+            String::from("c")],
+            vec![String::from("d")],
+            vec![String::from("e")],
+        ];
+        assert_eq!(val, correct);
+
+        let val = range.into_iter().group_by(|a, b| a == b).map(|x| x.into_iter().nth(0).unwrap()).collect::<Vec<String>>();
+        let correct = vec![
+            String::from("test"),
+            String::from("test2"),
+            String::from("a"),
+            String::from("b"),
+            String::from("c"),
+            String::from("d"),
+            String::from("e"),
+        ];
+        assert_eq!(val, correct);
+
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! Direct port of https://github.com/blachlylab/nbib/
 
-#![feature(slice_group_by)]
 
 mod tags;
 mod transforms;
 mod types;
+mod groupby;
 
 pub fn transmogrify(mut input: impl std::io::Read) -> Result<String, ()>
 {
@@ -23,9 +23,9 @@ pub fn transmogrify(mut input: impl std::io::Read) -> Result<String, ()>
 
     let e = d.map(transforms::medline_to_csl);
 
-    // let f = e.map(transforms::reduce_authors);
+    let f = e.map(|x| x.map(|y| y.unwrap())).map(transforms::reduce_authors);
 
-    println!("{:?}", e);
+    println!("{:?}", f.map(|x| x.collect::<Vec<types::CSLValue>>()).collect::<Vec<Vec<types::CSLValue>>>());
     Ok("Sorry, Not Finished".into())
 }
 

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -188,7 +188,7 @@ mod tests {
         let names: Vec<CSLValue> = csl.map(|x| x.unwrap()).filter(|x| x.is_name()).collect();
         assert_eq!(names.len(), 4);
 
-        let merged_rec: Vec<String> = merge_multiline_items(rec.into_iter()).collect();
+        let merged_rec = merge_multiline_items(rec.into_iter());
 
         let reduced = reduce_authors(medline_to_csl(merged_rec.into_iter()).map(|x| x.unwrap()));
         let names: Vec<CSLValue> = reduced.filter(|x| x.is_name()).collect();


### PR DESCRIPTION
I have managed to rework the existing functions into range/iterator functions.

This required making my own version of `group_by` and an Iterator type `MergeMultiline`. Rust's borrowing rules made this difficult in some places but I was able to avoid using `clone`. These changes would also mean we don't have to rely on nightly features.

Also now `medline_to_csl` now returns `Iterator<Result<CSLValue, String>>` instead of say `Result<Iterator<CSLValue>, String>` (before it returned `Result<Vec<CSLValue>, String>`). There may be a way to change it so that the original functionality still exists but I think it would require iterating the range which is not ideal.

Let me know what you think. This may not be the best or right approach but I wanted to see if I could do it and learn how to make ranges in Rust. 